### PR TITLE
Deprecate recipes that are duplicates or no longer maintained

### DIFF
--- a/Atlassian/HipChat.download.recipe
+++ b/Atlassian/HipChat.download.recipe
@@ -3,35 +3,16 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of HipChat.</string>
+	<string>Downloads the current release version of HipChat.
+
+This recipe is deprecated and will be removed in the future. Please use the recipe with this identifier instead: com.github.arubdesu.download.HipChat</string>
 	<key>Identifier</key>
 	<string>com.github.derak.download.HipChat</string>
 	<key>Input</key>
-	<dict>
-		<key>NAME</key>
-		<string>HipChat</string>
-		<key>DOWNLOAD_URL</key>
-		<string>https://www.hipchat.com/downloads/latest/mac</string>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<dict/>
+	<key>ParentRecipe</key>
+	<string>com.github.arubdesu.download.HipChat</string>
 	<key>Process</key>
-	<array>
-		<dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
-			<key>Arguments</key>
-			<dict>
-				<key>url</key>
-				<string>%DOWNLOAD_URL%</string>
-				<key>filename</key>
-				<string>%NAME%.zip</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
-		</dict>
-	</array>
+	<array/>
 </dict>
 </plist>

--- a/Atlassian/HipChat.munki.recipe
+++ b/Atlassian/HipChat.munki.recipe
@@ -3,78 +3,16 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of HipChat and imports into Munki.</string>
+	<string>Downloads the current release version of HipChat and imports into Munki.
+
+This recipe is deprecated and will be removed in the future. Please use the recipe with this identifier instead: com.github.arubdesu.munki.HipChat</string>
 	<key>Identifier</key>
 	<string>com.github.derak.munki.HipChat</string>
 	<key>Input</key>
-	<dict>
-		<key>NAME</key>
-		<string>HipChat</string>
-		<key>MUNKI_REPO_SUBDIR</key>
-		<string>apps/atlassian</string>
-		<key>pkginfo</key>
-		<dict>
-			<key>blocking_applications</key>
-			<array>
-				<string>HipChat</string>
-			</array>
-			<key>catalogs</key>
-			<array>
-				<string>testing</string>
-			</array>
-			<key>description</key>
-			<string>HipChat is hosted group chat and IM for companies and teams. Supercharge real-time collaboration with persistent chat rooms, file sharing, and chat history.</string>
-			<key>display_name</key>
-			<string>HipChat</string>
-			<key>name</key>
-			<string>%NAME%</string>
-			<key>unattended_install</key>
-			<true/>
-			<key>unattended_uninstall</key>
-			<true/>
-		</dict>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<dict/>
 	<key>ParentRecipe</key>
-	<string>com.github.derak.download.HipChat</string>
+	<string>com.github.arubdesu.munki.HipChat</string>
 	<key>Process</key>
-	<array>
-		<dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
-			<key>Arguments</key>
-			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-				<key>purge_destination</key>
-				<true/>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-			<key>Arguments</key>
-			<dict>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_path</key>
-				<string>%dmg_path%</string>
-				<key>repo_subdirectory</key>
-				<string>%MUNKI_REPO_SUBDIR%</string>
-			</dict>
-			<key>Processor</key>
-			<string>MunkiImporter</string>
-		</dict>
-	</array>
+	<array/>
 </dict>
 </plist>

--- a/BetterTouchTool/BetterTouchTool.munki.recipe
+++ b/BetterTouchTool/BetterTouchTool.munki.recipe
@@ -2,98 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Description</key>
-    <string>Downloads the current release version of BetterTouchTool and imports into Munki.</string>
-    <key>Identifier</key>
-    <string>com.github.derak.munki.BetterTouchTool</string>
-    <key>Input</key>
-    <dict>
-        <key>NAME</key>
-        <string>BetterTouchTool</string>
-        <key>MUNKI_REPO_SUBDIR</key>
-        <string>tools/bettertouchtool</string>
-        <key>SPARKLE_FEED_URL</key>
-        <string>http://appcast.boastr.net</string>
-        <key>pkginfo</key>
-        <dict>
-            <key>catalogs</key>
-            <array>
-                <string>testing</string>
-            </array>
-            <key>category</key>
-            <string>Utilities</string>
-            <key>developer</key>
-            <string>Andreas Hegenberg</string>
-            <key>description</key>
-            <string>BetterTouchTool is a great, feature packed FREE app that allows you to configure many gestures for your Magic Mouse, Macbook Trackpad and Magic Trackpad. It also allows you to configure actions for keyboard shortcuts, normal mice and the Apple Remote. In addition to this it has an iOS companion App (BTT Remote) which can also be configured to control your Mac the way you want.</string>
-            <key>display_name</key>
-            <string>BetterTouchTool</string>
-            <key>name</key>
-            <string>%NAME%</string>
-            <key>unattended_install</key>
-            <true/>
-        </dict>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>0.2.0</string>
-    <key>Process</key>
-    <array>
-        <dict>
-            <key>Processor</key>
-            <string>SparkleUpdateInfoProvider</string>
-            <key>Arguments</key>
-            <dict>
-                <key>appcast_url</key>
-                <string>%SPARKLE_FEED_URL%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>Unarchiver</string>
-            <key>Arguments</key>
-            <dict>
-                <key>archive_path</key>
-                <string>%pathname%</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                <key>purge_destination</key>
-                <true/>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>DmgCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>dmg_root</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                <key>dmg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiPkginfoMerger</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>pkg_path</key>
-                <string>%dmg_path%</string>
-                <key>repo_subdirectory</key>
-                <string>%MUNKI_REPO_SUBDIR%</string>
-            </dict>
-            <key>Processor</key>
-            <string>MunkiImporter</string>
-        </dict>
-    </array>
+	<key>Description</key>
+	<string>Downloads the current release version of BetterTouchTool and imports into Munki.
+
+This recipe is deprecated and will be removed in the future. Please use the recipe with this identifier instead: com.github.homebysix.munki.BetterTouchTool</string>
+	<key>Identifier</key>
+	<string>com.github.derak.munki.BetterTouchTool</string>
+	<key>Input</key>
+	<dict/>
+	<key>ParentRecipe</key>
+	<string>com.github.homebysix.munki.BetterTouchTool</string>
+	<key>Process</key>
+	<array/>
 </dict>
 </plist>

--- a/Google/GoogleDrive.download.recipe
+++ b/Google/GoogleDrive.download.recipe
@@ -2,36 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Description</key>
-    <string>Downloads latest Google Drive disk image.</string>
-    <key>Identifier</key>
-    <string>com.github.derak.download.GoogleDrive</string>
-    <key>Input</key>
-    <dict>
-        <key>NAME</key>
-        <string>GoogleDrive</string>
-        <key>DOWNLOAD_URL</key>
-        <string>https://dl.google.com/drive/installgoogledrive.dmg</string>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>0.2.0</string>
-    <key>Process</key>
-    <array>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%DOWNLOAD_URL%</string>
-                <key>filename</key>
-                <string>%NAME%.dmg</string>
-            </dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-    </array>
+	<key>Description</key>
+	<string>Downloads latest Google Drive disk image.
+
+This recipe is deprecated and will be removed in the future. Please use the recipe with this identifier instead: com.github.autopkg.recipes-dankeller.download.google-drive</string>
+	<key>Identifier</key>
+	<string>com.github.derak.download.GoogleDrive</string>
+	<key>Input</key>
+	<dict/>
+	<key>ParentRecipe</key>
+	<string>com.github.autopkg.recipes-dankeller.download.google-drive</string>
+	<key>Process</key>
+	<array/>
 </dict>
 </plist>

--- a/Google/GoogleDrive.munki.recipe
+++ b/Google/GoogleDrive.munki.recipe
@@ -3,75 +3,16 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest Google Drive disk image and imports into Munki.</string>
+	<string>Downloads the latest Google Drive disk image and imports into Munki.
+
+This recipe is deprecated and will be removed in the future. Please use the recipe with this identifier instead: com.github.autopkg.recipes-dankeller.munki.google-drive</string>
 	<key>Identifier</key>
 	<string>com.github.derak.munki.GoogleDrive</string>
 	<key>Input</key>
-	<dict>
-		<key>NAME</key>
-		<string>GoogleDrive</string>
-		<key>MUNKI_REPO_SUBDIR</key>
-		<string>apps/google</string>
-		<key>pkginfo</key>
-		<dict>
-			<key>catalogs</key>
-			<array>
-				<string>testing</string>
-			</array>
-			<key>description</key>
-			<string>Google Drive for Mac syncs any or all of your files to Google Drive on the web, making them available anywhere, at any time, on any device.</string>
-			<key>display_name</key>
-			<string>Google Drive</string>
-			<key>name</key>
-			<string>%NAME%</string>
-			<key>minimum_os_version</key>
-			<string>10.6</string>
-			<key>unattended_install</key>
-			<true/>
-		</dict>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<dict/>
 	<key>ParentRecipe</key>
-	<string>com.github.derak.download.GoogleDrive</string>
+	<string>com.github.autopkg.recipes-dankeller.munki.google-drive</string>
 	<key>Process</key>
-	<array>
-		<dict>
-			<key>Processor</key>
-			<string>Versioner</string>
-			<key>Arguments</key>
-			<dict>
-				<key>input_plist_path</key>
-				<string>%pathname%/Google Drive.app/Contents/Info.plist</string>
-				<key>plist_version_key</key>
-				<string>CFBundleVersion</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>MunkiPkginfoMerger</string>
-			<key>Arguments</key>
-			<dict>
-				<key>additional_pkginfo</key>
-				<dict>
-					<key>version</key>
-					<string>%version%</string>
-				</dict>
-			</dict>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_path</key>
-				<string>%pathname%</string>
-				<key>repo_subdirectory</key>
-				<string>%MUNKI_REPO_SUBDIR%</string>
-				<key>version_comparison_key</key>
-				<string>CFBundleVersion</string>
-			</dict>
-			<key>Processor</key>
-			<string>MunkiImporter</string>
-		</dict>
-	</array>
+	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
Having multiple similar recipes appear in `autopkg search` results can be confusing, especially for administrators who may not be comfortable reading and auditing AutoPkg recipes.

This pull request gently deprecates duplicate recipes, but ensures they'll still work by utilizing the ParentRecipe key to point to their replacement.